### PR TITLE
fix(security): update Tailscale from 1.98.4 to 1.98.10

### DIFF
--- a/tailscale/Dockerfile
+++ b/tailscale/Dockerfile
@@ -2,7 +2,7 @@
 # for weeks because Docker only re-resolves a FROM tag against the registry
 # when explicitly told to (docker pull / --pull), so a floating tag doesn't
 # actually keep you current without deliberate action. Bump this by hand.
-FROM tailscale/tailscale:v1.98.4
+FROM tailscale/tailscale:v1.98.10
 
 # Pre-install the auxiliary tools the entrypoint relies on (nginx for the
 # reverse proxy to the control panel — terminating optional HTTPS, curl


### PR DESCRIPTION
Update the Tailscale container image from v1.98.4 to v1.98.10.

The previous version contains a known security vulnerability. This update brings in the upstream security fix without changing the gateway configuration or runtime behavior.